### PR TITLE
feat: Build end-to-end WhatsApp image stylization bot

### DIFF
--- a/src/whatsapp_image_bot/api/webhooks.py
+++ b/src/whatsapp_image_bot/api/webhooks.py
@@ -1,55 +1,165 @@
 """Webhook handlers for the WhatsApp Image Stylization Bot.
 
-This module contains the core logic for receiving and processing
-incoming webhooks requests from Twilio.
+This module receives Twilio webhooks, orchestrates image stylization, and
+replies to the user. It keeps the FastAPI event-loop responsive by running
+blocking Twilio calls in executor threads.
 """
 
+import asyncio
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Form
+from fastapi import APIRouter, Depends, Form, Response
+from pydantic import BaseModel, Field
+from twilio.twiml.messaging_response import MessagingResponse
+
+from whatsapp_image_bot.services.image_processor import process_image
+from whatsapp_image_bot.services.whatsapp_client import WhatsAppClient
+from whatsapp_image_bot.utils.logger import get_logger
 
 router = APIRouter()
+logger = get_logger(__name__)
 
 
-# --- Pydantic Models for Webhook Requests ---
-# Define a dependency class for the Twilio webhook data.
-# FastAPI will automatically parse the incoming form data from Twilio
-# and populate the fields of this class.
-class TwilioWebhookRequest:
-    """Data model for Twilio webhook requests."""
+# ---------------------------------------------------------------------------
+# Incoming webhook data model (parsed from Twilio form‑encoded payload)
+# ---------------------------------------------------------------------------
+class TwilioWebhookRequest(BaseModel):
+    """Parsed payload for a Twilio WhatsApp webhook."""
 
-    def __init__(
-        self,
-        From: str = Form(...),
-        To: str = Form(...),
-        Body: Optional[str] = Form(None),
-        NumMedia: int = Form(0),
-        MediaUrl0: Optional[str] = Form(None),
-        MessageSid: str = Form(...),
-    ):
-        """Initialize the Twilio webhook request with the form data from Twilio."""
-        self.sender_number = From
-        self.receiver_number = To
-        self.body = Body
-        self.num_media = NumMedia
-        self.media_url = MediaUrl0
-        self.message_sid = MessageSid
+    sender_number: str = Field(
+        ...,
+        description="Sender (WhatsApp) number in E.164 format",
+        alias="From",
+        title="Sender (WhatsApp) number in E.164 format",
+    )
+    message_sid: str = Field(
+        ...,
+        description="Unique ID for this inbound message",
+        alias="MessageSid",
+        title="Unique ID for this inbound message",
+    )
+    num_media: int = Field(
+        ...,
+        description="How many media items were attached",
+        alias="NumMedia",
+        title="How many media items were attached",
+    )
+    media_url: Optional[str] = Field(
+        None,
+        description="URL of the first media item",
+        alias="MediaUrl0",
+        title="URL of the first media item",
+    )
+
+    # FastAPI cannot yet infer "application/x-www-form-urlencoded" into a
+    # Pydantic model directly.  The ``as_form`` helper bridges that gap so the
+    # model can still be injected with ``Depends`` *and* retain runtime
+    # validation + OpenAPI docs.
+    @classmethod
+    def as_form(  # noqa: N802 – keep Twilio’s original field names
+        cls,
+        From: str = Form(...),  # sender WhatsApp number
+        MessageSid: str = Form(...),  # unique inbound message SID
+        NumMedia: int = Form(0),  # number of media attachments
+        MediaUrl0: Optional[str] = Form(None),  # first media URL (if any)
+    ) -> "TwilioWebhookRequest":  # noqa: N803 – Twilio naming
+        """Create a TwilioWebhookRequest from form data."""
+        return cls(
+            From=From,
+            MessageSid=MessageSid,
+            NumMedia=NumMedia,
+            MediaUrl0=MediaUrl0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main webhook handler
+# ---------------------------------------------------------------------------
 
 
 @router.post("/")
 async def handle_incoming_message(
-    webhook_request: TwilioWebhookRequest = Depends(),  # noqa: B008
-):
-    """Handle incoming messages from Twilio."""
-    print("--- Incoming Webhook Data ---")
-    print(f"SID: {webhook_request.message_sid}")
-    print(f"From: {webhook_request.sender_number}")
-    print(f"To: {webhook_request.receiver_number}")
-    print(f"Body: {webhook_request.body}")
-    print(f"NumMedia: {webhook_request.num_media}")
-    if webhook_request.media_url:
-        print(f"MediaUrl0: {webhook_request.media_url}")
-    else:
-        print("No media URL found")
-    print("--- End of Incoming Webhook ---")
-    return ""
+    webhook_request: TwilioWebhookRequest = Depends(  # noqa: B008 – FastAPI pattern
+        TwilioWebhookRequest.as_form,
+    ),
+) -> Response:
+    """Process an incoming WhatsApp message and reply accordingly."""
+    # Use a single client instance per request; run its sync methods off-thread
+    whatsapp_client = WhatsAppClient()
+
+    # ------------------------------------------------------------------
+    # No image attached – ask the user for one
+    # ------------------------------------------------------------------
+    if webhook_request.num_media == 0 or not webhook_request.media_url:
+        logger.warning(
+            "Received message without image attachment.",
+            extra={
+                "sid": webhook_request.message_sid,
+                "from": webhook_request.sender_number,
+            },
+        )
+        await asyncio.to_thread(
+            whatsapp_client.send_reply,
+            to=webhook_request.sender_number,
+            body="Please send an image to get it stylized! 🖼️",
+        )
+        return Response(str(MessagingResponse()), media_type="application/xml")
+
+    # ------------------------------------------------------------------
+    # Image received – acknowledge and start processing
+    # ------------------------------------------------------------------
+    logger.info(
+        "Image received - starting stylization",
+        extra={
+            "sid": webhook_request.message_sid,
+            "from": webhook_request.sender_number,
+        },
+    )
+    await asyncio.to_thread(
+        whatsapp_client.send_reply,
+        to=webhook_request.sender_number,
+        body="Got it! Stylizing your image now… This might take a moment. ✨",
+    )
+
+    # ------------------------------------------------------------------
+    # Run the heavy lifting: stylize + upload
+    # ------------------------------------------------------------------
+    try:
+        final_url = await process_image(
+            original_url=webhook_request.media_url,  # type: ignore[arg-type]
+            message_sid=webhook_request.message_sid,
+        )
+
+        # Send back the stylized image
+        await asyncio.to_thread(
+            whatsapp_client.send_reply,
+            to=webhook_request.sender_number,
+            body="Here's your stylized image! 🖼️",
+            media_url=final_url,
+        )
+        logger.info(
+            "Stylized image sent",
+            extra={
+                "sid": webhook_request.message_sid,
+                "to": webhook_request.sender_number,
+            },
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to process image",
+            exc_info=True,
+            extra={
+                "sid": webhook_request.message_sid,
+                "error": str(exc),
+            },
+        )
+        await asyncio.to_thread(
+            whatsapp_client.send_reply,
+            to=webhook_request.sender_number,
+            body="Sorry, something went wrong while stylizing your image. Please try again later. 😟",
+        )
+
+    # ------------------------------------------------------------------
+    # Always return an empty TwiML response; Twilio only needs ACK.
+    # ------------------------------------------------------------------
+    return Response(str(MessagingResponse()), media_type="application/xml")

--- a/src/whatsapp_image_bot/api/webhooks.py
+++ b/src/whatsapp_image_bot/api/webhooks.py
@@ -1,17 +1,20 @@
 """Webhook handlers for the WhatsApp Image Stylization Bot.
 
-This module receives Twilio webhooks, orchestrates image stylization, and
-replies to the user. It keeps the FastAPI event-loop responsive by running
-blocking Twilio calls in executor threads.
+This module receives Twilio webhooks, verifies authenticity, orchestrates image
+stylization, and replies to the user. It keeps the FastAPI event-loop responsive
+by running blocking Twilio calls in executor threads.
 """
 
 import asyncio
-from typing import Optional
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlparse
 
-from fastapi import APIRouter, Depends, Form, Response
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Request, Response, status
+from pydantic import BaseModel, Field, ValidationError
+from twilio.request_validator import RequestValidator
 from twilio.twiml.messaging_response import MessagingResponse
 
+from whatsapp_image_bot.config import Config
 from whatsapp_image_bot.services.image_processor import process_image
 from whatsapp_image_bot.services.whatsapp_client import WhatsAppClient
 from whatsapp_image_bot.utils.logger import get_logger
@@ -19,94 +22,190 @@ from whatsapp_image_bot.utils.logger import get_logger
 router = APIRouter()
 logger = get_logger(__name__)
 
+# Reusable client (lightweight wrapper around Twilio REST).
+_whatsapp_client = WhatsAppClient()
+
 
 # ---------------------------------------------------------------------------
-# Incoming webhook data model (parsed from Twilio form‑encoded payload)
+# Incoming webhook data model
 # ---------------------------------------------------------------------------
 class TwilioWebhookRequest(BaseModel):
     """Parsed payload for a Twilio WhatsApp webhook."""
 
-    sender_number: str = Field(
-        ...,
-        description="Sender (WhatsApp) number in E.164 format",
-        alias="From",
-        title="Sender (WhatsApp) number in E.164 format",
-    )
-    message_sid: str = Field(
-        ...,
-        description="Unique ID for this inbound message",
-        alias="MessageSid",
-        title="Unique ID for this inbound message",
-    )
-    num_media: int = Field(
-        ...,
-        description="How many media items were attached",
-        alias="NumMedia",
-        title="How many media items were attached",
-    )
-    media_url: Optional[str] = Field(
-        None,
-        description="URL of the first media item",
-        alias="MediaUrl0",
-        title="URL of the first media item",
-    )
+    sender_number: str = Field(..., alias="From")
+    message_sid: str = Field(..., alias="MessageSid")
+    num_media: int = Field(..., alias="NumMedia")
+    media_url: Optional[str] = Field(None, alias="MediaUrl0")
 
-    # FastAPI cannot yet infer "application/x-www-form-urlencoded" into a
-    # Pydantic model directly.  The ``as_form`` helper bridges that gap so the
-    # model can still be injected with ``Depends`` *and* retain runtime
-    # validation + OpenAPI docs.
-    @classmethod
-    def as_form(  # noqa: N802 – keep Twilio’s original field names
-        cls,
-        From: str = Form(...),  # sender WhatsApp number
-        MessageSid: str = Form(...),  # unique inbound message SID
-        NumMedia: int = Form(0),  # number of media attachments
-        MediaUrl0: Optional[str] = Form(None),  # first media URL (if any)
-    ) -> "TwilioWebhookRequest":  # noqa: N803 – Twilio naming
-        """Create a TwilioWebhookRequest from form data."""
-        return cls(
-            From=From,
-            MessageSid=MessageSid,
-            NumMedia=NumMedia,
-            MediaUrl0=MediaUrl0,
+    def to_signature_dict(self) -> Dict[str, Any]:
+        """Twilio signature validation needs the *original* form parameter names.
+
+        Return only the fields we model; unmodeled fields are still validated
+        via raw parse (see _parse_form_and_verify_signature).
+        """
+        return {
+            "From": self.sender_number,
+            "MessageSid": self.message_sid,
+            "NumMedia": str(self.num_media),
+            **({"MediaUrl0": self.media_url} if self.media_url else {}),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ALLOWED_MEDIA_SCHEMES = {"http", "https"}
+ALLOWED_MEDIA_HOST_SUFFIXES = {
+    "twilio.com",
+    "api.twilio.com",
+    "amazonaws.com",
+    # Add other trusted domains
+}
+
+
+def _is_allowed_media_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ALLOWED_MEDIA_SCHEMES:
+            return False
+        host = (parsed.hostname or "").lower()
+        return any(host.endswith(suf) for suf in ALLOWED_MEDIA_HOST_SUFFIXES)
+    except Exception:
+        return False
+
+
+async def _safe_send_reply(*, to: str, body: str, media_url: str | None = None) -> None:
+    """Run the blocking Twilio client send off-thread with logging guard."""
+    try:
+        await asyncio.to_thread(
+            _whatsapp_client.send_reply,
+            to=to,
+            body=body,
+            media_url=media_url,
         )
+    except Exception:
+        # Do not let a reply failure break the webhook 200 response to Twilio
+        logger.exception("Failed to send WhatsApp reply", extra={"to": to})
+
+
+def _twiml_empty() -> Response:
+    """Return an empty TwiML ACK."""
+    return Response(str(MessagingResponse()), media_type="application/xml")
+
+
+async def _parse_form_and_verify_signature(request: Request) -> Dict[str, str]:
+    """Read raw body, parse form fields before trust, and verify Twilio signature.
+
+    Returns a dict of all form params (string -> string).
+
+    IMPORTANT: Twilio signature uses the full URL including scheme + host + path + query.
+    """
+    cfg = Config()
+    if not cfg.TWILIO_AUTH_TOKEN:
+        logger.warning(
+            "Twilio auth token missing; skipping signature verification (UNSAFE)."
+        )
+        body_bytes = await request.body()
+        return dict(parse_qsl(body_bytes.decode("utf-8"), keep_blank_values=True))
+
+    body_bytes = await request.body()
+    body_str = body_bytes.decode("utf-8")
+    form_pairs = parse_qsl(body_str, keep_blank_values=True)
+    params = dict(form_pairs)
+
+    received_sig = request.headers.get("X-Twilio-Signature", "")
+    validator = RequestValidator(cfg.TWILIO_AUTH_TOKEN)
+    full_url = str(request.url)  # Twilio docs: use full URL
+
+    if not validator.validate(full_url, params, received_sig):
+        logger.warning("Twilio signature validation failed", extra={"url": full_url})
+        # Intentionally return 403 without revealing details
+        raise SignatureError("Invalid Twilio signature")
+
+    return params
+
+
+# Custom lightweight exception for clarity
+class SignatureError(Exception):
+    """Custom exception for signature validation errors."""
+
+    pass
 
 
 # ---------------------------------------------------------------------------
 # Main webhook handler
 # ---------------------------------------------------------------------------
-
-
 @router.post("/")
-async def handle_incoming_message(
-    webhook_request: TwilioWebhookRequest = Depends(  # noqa: B008 – FastAPI pattern
-        TwilioWebhookRequest.as_form,
-    ),
-) -> Response:
-    """Process an incoming WhatsApp message and reply accordingly."""
-    # Use a single client instance per request; run its sync methods off-thread
-    whatsapp_client = WhatsAppClient()
+async def handle_incoming_message(request: Request) -> Response:
+    """Process an incoming WhatsApp message and reply accordingly.
+
+    Steps:
+        1. Verify Twilio signature
+        2. Validate & parse payload
+        3. Handle no-media vs. media flow
+        4. Dispatch processing
+    """
+    try:
+        raw_params = await _parse_form_and_verify_signature(request)
+    except SignatureError:
+        # Deliberately minimal info; respond 403 so Twilio can notice & you can debug
+        return Response(status_code=status.HTTP_403_FORBIDDEN)
+    except Exception:
+        logger.exception("Unexpected error during signature verification")
+        return Response(status_code=status.HTTP_400_BAD_REQUEST)
+
+    # Parse into model (will raise ValidationError if mismatched)
+    try:
+        typed_params: Dict[str, Any] = dict(raw_params)  # widen value type
+
+        # Explicit conversions (guard for presence)
+        if "NumMedia" in typed_params:
+            try:
+                typed_params["NumMedia"] = int(typed_params["NumMedia"])
+            except ValueError:
+                typed_params["NumMedia"] = 0  # or raise / log
+
+        webhook_request = TwilioWebhookRequest(**typed_params)
+    except ValidationError as ve:
+        logger.warning("Invalid Twilio webhook payload", extra={"errors": ve.errors()})
+        return _twiml_empty()
 
     # ------------------------------------------------------------------
-    # No image attached – ask the user for one
+    # No image attached
     # ------------------------------------------------------------------
     if webhook_request.num_media == 0 or not webhook_request.media_url:
-        logger.warning(
-            "Received message without image attachment.",
+        logger.info(
+            "Message without image attachment",
             extra={
                 "sid": webhook_request.message_sid,
                 "from": webhook_request.sender_number,
             },
         )
-        await asyncio.to_thread(
-            whatsapp_client.send_reply,
+        await _safe_send_reply(
             to=webhook_request.sender_number,
             body="Please send an image to get it stylized! 🖼️",
         )
-        return Response(str(MessagingResponse()), media_type="application/xml")
+        return _twiml_empty()
 
     # ------------------------------------------------------------------
-    # Image received – acknowledge and start processing
+    # Validate media URL origin (basic allow-list)
+    # ------------------------------------------------------------------
+    if not _is_allowed_media_url(webhook_request.media_url):
+        logger.warning(
+            "Rejected media URL (not in allow-list)",
+            extra={
+                "sid": webhook_request.message_sid,
+                "url": webhook_request.media_url,
+            },
+        )
+        await _safe_send_reply(
+            to=webhook_request.sender_number,
+            body="That media host is not supported. Please resend an image from WhatsApp directly.",
+        )
+        return _twiml_empty()
+
+    # ------------------------------------------------------------------
+    # Acknowledge receipt
     # ------------------------------------------------------------------
     logger.info(
         "Image received - starting stylization",
@@ -115,24 +214,40 @@ async def handle_incoming_message(
             "from": webhook_request.sender_number,
         },
     )
-    await asyncio.to_thread(
-        whatsapp_client.send_reply,
+    await _safe_send_reply(
         to=webhook_request.sender_number,
         body="Got it! Stylizing your image now… This might take a moment. ✨",
     )
 
     # ------------------------------------------------------------------
-    # Run the heavy lifting: stylize + upload
+    # Process image
     # ------------------------------------------------------------------
     try:
         final_url = await process_image(
-            original_url=webhook_request.media_url,  # type: ignore[arg-type]
+            original_url=webhook_request.media_url,
             message_sid=webhook_request.message_sid,
         )
-
-        # Send back the stylized image
-        await asyncio.to_thread(
-            whatsapp_client.send_reply,
+    except ValueError as ve:
+        # Anticipated validation issues (e.g. unsupported MIME later)
+        logger.warning(
+            "Image validation or processing error",
+            extra={"sid": webhook_request.message_sid, "error": str(ve)},
+        )
+        await _safe_send_reply(
+            to=webhook_request.sender_number,
+            body="That image could not be processed (validation error). Try another one.",
+        )
+    except Exception:
+        logger.exception(
+            "Unhandled error processing image",
+            extra={"sid": webhook_request.message_sid},
+        )
+        await _safe_send_reply(
+            to=webhook_request.sender_number,
+            body="Sorry, something went wrong while stylizing your image. Please try again later. 😟",
+        )
+    else:
+        await _safe_send_reply(
             to=webhook_request.sender_number,
             body="Here's your stylized image! 🖼️",
             media_url=final_url,
@@ -144,22 +259,5 @@ async def handle_incoming_message(
                 "to": webhook_request.sender_number,
             },
         )
-    except Exception as exc:
-        logger.error(
-            "Failed to process image",
-            exc_info=True,
-            extra={
-                "sid": webhook_request.message_sid,
-                "error": str(exc),
-            },
-        )
-        await asyncio.to_thread(
-            whatsapp_client.send_reply,
-            to=webhook_request.sender_number,
-            body="Sorry, something went wrong while stylizing your image. Please try again later. 😟",
-        )
 
-    # ------------------------------------------------------------------
-    # Always return an empty TwiML response; Twilio only needs ACK.
-    # ------------------------------------------------------------------
-    return Response(str(MessagingResponse()), media_type="application/xml")
+    return _twiml_empty()

--- a/src/whatsapp_image_bot/app.py
+++ b/src/whatsapp_image_bot/app.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel
 
 from .api import api_router
 from .config import Config
+from .services.image_processor import shutdown_clients
+from .utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 # --- Pydantic Models for Responses ---
@@ -28,6 +32,14 @@ app = FastAPI(
     description="API for processing and stylizing images from WhatsApp.",
     version="0.1.0",
 )
+
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    """Gracefully close any open clients or connections."""
+    logger.info("Application shutting down. Closing clients.")
+    await shutdown_clients()
+
 
 # Load configuration (can be used in other parts of the app if needed)
 app_config = Config()

--- a/src/whatsapp_image_bot/services/image_processor.py
+++ b/src/whatsapp_image_bot/services/image_processor.py
@@ -40,6 +40,7 @@ async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
 
     async with httpx.AsyncClient(
         auth=httpx.BasicAuth(cfg.TWILIO_ACCOUNT_SID, cfg.TWILIO_AUTH_TOKEN),
+        follow_redirects=True,
     ) as client:
         response = await client.get(url)
         response.raise_for_status()

--- a/src/whatsapp_image_bot/services/image_processor.py
+++ b/src/whatsapp_image_bot/services/image_processor.py
@@ -9,16 +9,67 @@ to upload the image to S3.
 """
 
 import asyncio
+import mimetypes
 import os
 import time
 from urllib.parse import urlparse
 
-from whatsapp_image_bot.clients import FalClient
-from whatsapp_image_bot.services import S3StorageService
-from whatsapp_image_bot.utils import download_image_from_url, get_logger
+import httpx
+
+from whatsapp_image_bot.clients.fal_client import FalClient
+from whatsapp_image_bot.config import Config
+from whatsapp_image_bot.services.cloud_storage import S3StorageService
+from whatsapp_image_bot.utils.helpers import download_image_from_url
+from whatsapp_image_bot.utils.logger import get_logger
 
 logger = get_logger(__name__)
 s3_service = S3StorageService()
+
+
+async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
+    """Ensure a URL is publicly accessible.
+
+    If Twilio media URL, returns a new public S3 URL.
+    """
+    if not url.startswith("https://api.twilio.com"):
+        return url
+
+    cfg = Config()
+    if not cfg.TWILIO_ACCOUNT_SID or not cfg.TWILIO_AUTH_TOKEN:
+        raise ValueError("Twilio credentials are not configured.")
+
+    async with httpx.AsyncClient(
+        auth=httpx.BasicAuth(cfg.TWILIO_ACCOUNT_SID, cfg.TWILIO_AUTH_TOKEN),
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+
+    # Upload the original image to S3 so fal.ai can reach it
+    # Get the extension from the URL
+    ctype = response.headers.get("Content-Type", "") or ""
+    base_type = ctype.split(";")[0].strip().lower()
+
+    # Guard image types
+    if not base_type.startswith("image/"):
+        raise ValueError(f"Unsupported media type: {base_type}")
+
+    # Normalize common JPEG quirk
+    if base_type in {"image/jpeg", "image/jpg"}:
+        orig_ext = ".jpg"
+    else:
+        orig_ext = mimetypes.guess_extension(base_type) or ".jpg"
+    orig_key = f"original/{message_sid}_{ts}{orig_ext}"
+    uploaded_url = await asyncio.to_thread(
+        s3_service.upload_file,
+        file_bytes=response.content,
+        object_name=orig_key,
+    )
+    if not uploaded_url:
+        raise Exception("Failed to upload original image to S3.")
+    public_input_url = uploaded_url
+    logger.info("Re-hosted Twilio image", extra={"url": public_input_url})
+
+    return public_input_url
 
 
 async def process_image(original_url: str, message_sid: str) -> str:
@@ -39,10 +90,17 @@ async def process_image(original_url: str, message_sid: str) -> str:
 
     """
     try:
+        start_time = time.perf_counter()
         fal_client = FalClient()
 
+        # Get the current timestamp
+        ts = int(time.time())
+
+        # 0. If it's a Twilio URL, fetch & re-host first
+        public_input_url = await _ensure_public_url(original_url, message_sid, ts)
+
         # 1. Stylize the image
-        stylized_url = await fal_client.stylize_image(original_url)
+        stylized_url = await fal_client.stylize_image(public_input_url)
         logger.info("Stylized image URL", extra={"url": stylized_url})
 
         # 2. Get image bytes from stylized URL
@@ -52,8 +110,10 @@ async def process_image(original_url: str, message_sid: str) -> str:
         logger.info("Image downloaded from stylized URL")
 
         # 3. Create a unique object name for the image
-        ext = os.path.splitext(urlparse(stylized_url).path)[1] or ".jpg"
-        object_name = f"processed/{message_sid}_{int(time.time())}{ext}"
+        styled_ext = os.path.splitext(urlparse(stylized_url).path)[1] or ".jpg"
+        # Normalize styled extension
+        styled_ext = styled_ext.lower()
+        object_name = f"processed/{message_sid}_{ts}{styled_ext}"
 
         # 4. Upload (run blocking boto3 call in a thread)
         s3_url: str | None = await asyncio.to_thread(
@@ -66,7 +126,11 @@ async def process_image(original_url: str, message_sid: str) -> str:
         if s3_url is None:
             raise Exception("Failed to upload image to S3.")
 
-        logger.info("Uploaded to S3", extra={"sid": message_sid, "url": s3_url})
+        elapsed_ms = round((time.perf_counter() - start_time) * 1000, 1)
+        logger.info(
+            "Uploaded to S3",
+            extra={"sid": message_sid, "url": s3_url, "elapsed_ms": elapsed_ms},
+        )
         return s3_url
 
     except Exception:

--- a/src/whatsapp_image_bot/services/image_processor.py
+++ b/src/whatsapp_image_bot/services/image_processor.py
@@ -204,7 +204,12 @@ async def process_image(
         elapsed_ms = round((time.perf_counter() - start_time) * 1000, 1)
         logger.info(
             "Uploaded to S3",
-            extra={"sid": message_sid, "url": s3_url, "elapsed_ms": elapsed_ms},
+            extra={
+                "sid": message_sid,
+                "url": s3_url,
+                "elapsed_ms": elapsed_ms,
+                "public_input_url": public_input_url,
+            },
         )
         return s3_url
 

--- a/src/whatsapp_image_bot/services/image_processor.py
+++ b/src/whatsapp_image_bot/services/image_processor.py
@@ -25,6 +25,58 @@ from whatsapp_image_bot.utils.logger import get_logger
 logger = get_logger(__name__)
 s3_service = S3StorageService()
 
+# Explicit exports
+__all__ = ["process_image", "MediaValidationError", "MediaDownloadError", "UploadError"]
+
+
+# ---------------------------------------------------------------------------
+# Configuration / guards
+# ---------------------------------------------------------------------------
+HTTP_TIMEOUT = 15.0  # seconds
+RETRY_STATUSES = {502, 503, 504}
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB (adjust if needed)
+ALLOWED_IMAGE_MIME = {
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+}
+
+
+# ---------------------------------------------------------------------------
+# Custom exceptions (narrower handling upstream)
+# ---------------------------------------------------------------------------
+class MediaValidationError(ValueError):
+    """Raised when media fails validation (mime/size/etc)."""
+
+
+class MediaDownloadError(RuntimeError):
+    """Raised when media cannot be downloaded/retrieved."""
+
+
+class UploadError(RuntimeError):
+    """Raised when S3 upload fails."""
+
+
+async def _fetch_with_retry(url: str, client: httpx.AsyncClient) -> httpx.Response:
+    """Fetch URL with basic retry on transient statuses."""
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        try:
+            resp = await client.get(url, timeout=HTTP_TIMEOUT)
+            if resp.status_code in RETRY_STATUSES and attempt < 2:
+                await asyncio.sleep(0.4 * (attempt + 1))
+                continue
+            resp.raise_for_status()
+            return resp
+        except Exception as exc:  # noqa: BLE001 - intentionally broad inside retry loop
+            last_exc = exc
+            if attempt == 2:
+                raise
+            await asyncio.sleep(0.4 * (attempt + 1))
+    assert last_exc  # for type checker
+    raise last_exc
+
 
 async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
     """Ensure a URL is publicly accessible.
@@ -36,14 +88,16 @@ async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
 
     cfg = Config()
     if not cfg.TWILIO_ACCOUNT_SID or not cfg.TWILIO_AUTH_TOKEN:
-        raise ValueError("Twilio credentials are not configured.")
+        raise MediaValidationError("Twilio credentials are not configured.")
 
     async with httpx.AsyncClient(
         auth=httpx.BasicAuth(cfg.TWILIO_ACCOUNT_SID, cfg.TWILIO_AUTH_TOKEN),
         follow_redirects=True,
     ) as client:
-        response = await client.get(url)
-        response.raise_for_status()
+        try:
+            response = await _fetch_with_retry(url, client)
+        except Exception as exc:
+            raise MediaDownloadError(f"Failed to download Twilio media: {exc}") from exc
 
     # Upload the original image to S3 so fal.ai can reach it
     # Get the extension from the URL
@@ -51,8 +105,12 @@ async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
     base_type = ctype.split(";")[0].strip().lower()
 
     # Guard image types
-    if not base_type.startswith("image/"):
-        raise ValueError(f"Unsupported media type: {base_type}")
+    if base_type not in ALLOWED_IMAGE_MIME:
+        raise MediaValidationError(f"Unsupported media type: {base_type or 'unknown'}")
+
+    # Size guard
+    if len(response.content) > MAX_IMAGE_BYTES:
+        raise MediaValidationError("Original image exceeds size limit.")
 
     # Normalize common JPEG quirk
     if base_type in {"image/jpeg", "image/jpg"}:
@@ -66,20 +124,28 @@ async def _ensure_public_url(url: str, message_sid: str, ts: int) -> str:
         object_name=orig_key,
     )
     if not uploaded_url:
-        raise Exception("Failed to upload original image to S3.")
+        raise UploadError("Failed to upload original image to S3.")
     public_input_url = uploaded_url
     logger.info("Re-hosted Twilio image", extra={"url": public_input_url})
 
     return public_input_url
 
 
-async def process_image(original_url: str, message_sid: str) -> str:
+async def process_image(
+    original_url: str,
+    message_sid: str,
+    *,
+    s3: S3StorageService | None = None,
+    fal_client: FalClient | None = None,
+) -> str:
     """Process an image from a URL and upload it to S3.
 
     Args:
     ----
         original_url: The URL of the original image.
         message_sid: The SID of the message.
+        s3: Optional S3 storage service for dependency injection.
+        fal_client: Optional Fal Client for dependency injection.
 
     Returns:
     -------
@@ -87,12 +153,16 @@ async def process_image(original_url: str, message_sid: str) -> str:
 
     Raises:
     ------
-        Exception: If the image is not uploaded to S3.
+        MediaValidationError: If the media fails validation (type, size).
+        MediaDownloadError: If the media cannot be downloaded.
+        UploadError: If the S3 upload fails.
 
     """
-    try:
+    s3 = s3 or s3_service
+    fal_client = fal_client or FalClient()
+
+    try:  # noqa: TRY301 - keep single main try for logging & timing
         start_time = time.perf_counter()
-        fal_client = FalClient()
 
         # Get the current timestamp
         ts = int(time.time())
@@ -107,25 +177,29 @@ async def process_image(original_url: str, message_sid: str) -> str:
         # 2. Get image bytes from stylized URL
         image_bytes = await download_image_from_url(stylized_url)
         if not image_bytes:
-            raise ValueError("No bytes downloaded from stylized URL.")
+            raise MediaDownloadError("No bytes downloaded from stylized URL.")
+        if len(image_bytes) > MAX_IMAGE_BYTES:
+            raise MediaValidationError("Stylized image exceeds size limit.")
         logger.info("Image downloaded from stylized URL")
 
         # 3. Create a unique object name for the image
         styled_ext = os.path.splitext(urlparse(stylized_url).path)[1] or ".jpg"
         # Normalize styled extension
         styled_ext = styled_ext.lower()
+        if styled_ext not in {".jpg", ".jpeg", ".png", ".webp"}:
+            styled_ext = ".jpg"
         object_name = f"processed/{message_sid}_{ts}{styled_ext}"
 
         # 4. Upload (run blocking boto3 call in a thread)
         s3_url: str | None = await asyncio.to_thread(
-            s3_service.upload_file,
+            s3.upload_file,
             file_bytes=image_bytes,
             object_name=object_name,
         )
 
         # If the image is not uploaded, raise an error
         if s3_url is None:
-            raise Exception("Failed to upload image to S3.")
+            raise UploadError("Failed to upload image to S3.")
 
         elapsed_ms = round((time.perf_counter() - start_time) * 1000, 1)
         logger.info(
@@ -134,6 +208,12 @@ async def process_image(original_url: str, message_sid: str) -> str:
         )
         return s3_url
 
+    except (MediaValidationError, MediaDownloadError, UploadError):
+        # Log at warning for expected failure modes
+        logger.warning("Processing error", exc_info=True, extra={"sid": message_sid})
+        raise
     except Exception:
-        logger.exception("Error processing image", extra={"sid": message_sid})
+        logger.exception(
+            "Unexpected error processing image", extra={"sid": message_sid}
+        )
         raise


### PR DESCRIPTION
### Description:

#### What does this PR do?
This PR introduces a complete, end-to-end WhatsApp bot that stylizes images sent by users. It includes a FastAPI server that listens for Twilio webhooks, processes images using an AI service, and replies to the user.

- **Receives Images**: Listens for incoming WhatsApp messages via a Twilio webhook.
- **Processes Images**: Uses **fal.ai** to apply a new style to the user's image.
- **Stores Images**: Uploads the final stylized image to an **AWS S3** bucket for permanent storage.
- **Replies to User**: Sends the stylized image back to the user via the Twilio API. It also handles cases where a user sends a message without an image.

#### How to test this?
1.  Ensure the `.env` file is populated with the necessary API keys for **Twilio**, **fal.ai**, and **AWS**.
2.  Run the server locally with `uvicorn src.whatsapp_image_bot.app:app --reload`.
3.  Expose the local server to the internet using `ngrok http 8000`.
4.  Update the **Twilio Sandbox** webhook URL to point to the `ngrok` forwarding address.
5.  Send an image to the WhatsApp Sandbox number to test the full stylization flow.